### PR TITLE
Add Supabase integration endpoints and deployment docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Database
 DATABASE_URL="postgresql://username:password@localhost:5432/famspace_db"
+DIRECT_URL="postgresql://username:password@localhost:5432/famspace_db"
 
 # JWT
 JWT_SECRET="your-super-secret-jwt-key-change-this-in-production"
@@ -13,6 +14,13 @@ NODE_ENV="development"
 
 # Logging
 LOG_LEVEL="info"
+
+# Supabase (optional)
+SUPABASE_AUTH_ENABLED="false"
+SUPABASE_URL=""
+SUPABASE_ANON_KEY=""
+SUPABASE_SERVICE_ROLE_KEY=""
+SUPABASE_JWT_SECRET=""
 
 # AI Services (for future use)
 OPENAI_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -50,12 +50,49 @@ A household administration app designed for UK families and people living togeth
 - `npm run dev` - Start development server with hot reload
 - `npm run build` - Build for production
 - `npm start` - Start production server
+- `npm run vercel-build` - Build command optimised for Vercel deployments (runs Prisma generate & deploy)
 - `npm test` - Run tests
 - `npm run test:watch` - Run tests in watch mode
 - `npm run db:generate` - Generate Prisma client
 - `npm run db:push` - Push schema changes to database
 - `npm run db:migrate` - Run database migrations
+- `npm run db:deploy` - Deploy migrations in production environments
 - `npm run db:studio` - Open Prisma Studio
+
+## Supabase & Vercel Deployment
+
+FamSpace can be deployed to [Vercel](https://vercel.com/) using [Supabase](https://supabase.com/) as the managed PostgreSQL provider. The application ships with a Supabase integration that allows you to exchange Supabase session tokens for FamSpace JWTs and automatically sync users from Supabase into the local database.
+
+### 1. Configure Supabase
+
+1. Create a new Supabase project.
+2. In the **Project Settings → Database** page copy both the standard connection string and the connection pooling string (pgbouncer).
+3. In Supabase **Authentication → Providers** ensure email sign-in is enabled and note the project URL and anon/service role keys.
+
+### 2. Environment variables
+
+Set the following values locally (`.env`) and in Vercel → **Project Settings → Environment Variables**:
+
+| Variable | Description |
+| --- | --- |
+| `DATABASE_URL` | The **connection pooling** URL from Supabase. Include `?pgbouncer=true&connection_limit=1` for serverless environments. |
+| `DIRECT_URL` | The normal database connection string (without pooling) for running Prisma migrations. |
+| `SUPABASE_AUTH_ENABLED` | Set to `true` to enable Supabase token exchange endpoints. |
+| `SUPABASE_URL` | Supabase project URL. |
+| `SUPABASE_ANON_KEY` | Supabase anon key for public clients. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key used to verify tokens server-side. |
+| `SUPABASE_JWT_SECRET` | (Optional) Supabase JWT secret if you need to verify tokens manually elsewhere. |
+
+When deploying on Vercel, set the **Build Command** to `npm run vercel-build` to ensure the Prisma client is generated and migrations are applied (`prisma migrate deploy`).
+
+### 3. Supabase authentication flow
+
+1. Let your front-end authenticate users with Supabase (e.g. using `@supabase/supabase-js`).
+2. Send the Supabase session access token to `POST /api/auth/supabase/exchange`.
+3. The API will verify the Supabase token, sync/create the user in Prisma, and return FamSpace access/refresh tokens.
+4. Use the FamSpace tokens to call the rest of the protected API routes.
+
+You can check the integration status by calling `GET /api/auth/supabase/status`.
 
 ## Project Structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@prisma/client": "^5.7.1",
+        "@supabase/supabase-js": "^2.57.4",
         "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -906,6 +907,80 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.6.tgz",
+      "integrity": "sha512-bhjZ7rmxAibjgmzTmQBxJU6ZIBCCJTc3Uwgvdi4FewueUTAGO5hxZT1Sj6tiD+0dSXf9XI87BDdJrg12z8Uaew==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.21.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.21.4.tgz",
+      "integrity": "sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.5",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.5.tgz",
+      "integrity": "sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.12.1.tgz",
+      "integrity": "sha512-QWg3HV6Db2J81VQx0PqLq0JDBn4Q8B1FYn1kYcbla8+d5WDmTdwwMr+EJAxNOSs9W4mhKMv+EYCpCrTFlTj4VQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.57.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.57.4.tgz",
+      "integrity": "sha512-LcbTzFhHYdwfQ7TRPfol0z04rLEyHabpGYANME6wkQ/kLtKNmI+Vy+WEM8HxeOZAtByUFxoUTTLwhXmrh+CcVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.6",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.21.4",
+        "@supabase/realtime-js": "2.15.5",
+        "@supabase/storage-js": "2.12.1"
+      }
+    },
     "node_modules/@types/bcryptjs": {
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
@@ -1027,11 +1102,16 @@
       "version": "20.19.14",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.14.tgz",
       "integrity": "sha512-gqiKWld3YIkmtrrg9zDvg9jfksZCcPywXVN7IauUGhilwGV/yOyeUsvpR796m/Jye0zUzMXPKe8Ct1B79A7N5Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -1098,6 +1178,15 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
@@ -3261,6 +3350,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -3338,7 +3433,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -4003,6 +4097,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4090,6 +4200,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "dev:clean": "./scripts/kill-server.sh && npm run dev",
+    "vercel-build": "prisma generate && prisma migrate deploy && npm run build",
     "test": "vitest --run",
     "test:watch": "vitest",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
+    "db:deploy": "prisma migrate deploy",
     "db:studio": "prisma studio",
     "kill-server": "./scripts/kill-server.sh"
   },
@@ -26,26 +28,27 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "express": "^4.18.2",
-    "cors": "^2.8.5",
-    "helmet": "^7.1.0",
-    "dotenv": "^16.3.1",
-    "winston": "^3.11.0",
-    "jsonwebtoken": "^9.0.2",
+    "@prisma/client": "^5.7.1",
+    "@supabase/supabase-js": "^2.57.4",
     "bcryptjs": "^2.4.3",
-    "@prisma/client": "^5.7.1"
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "helmet": "^7.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "winston": "^3.11.0"
   },
   "devDependencies": {
-    "@types/express": "^4.17.21",
-    "@types/cors": "^2.8.17",
-    "@types/jsonwebtoken": "^9.0.5",
     "@types/bcryptjs": "^2.4.6",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.10.5",
     "@types/supertest": "^2.0.16",
-    "typescript": "^5.3.3",
-    "tsx": "^4.6.2",
-    "vitest": "^1.1.0",
+    "prisma": "^5.7.1",
     "supertest": "^6.3.3",
-    "prisma": "^5.7.1"
+    "tsx": "^4.6.2",
+    "typescript": "^5.3.3",
+    "vitest": "^1.1.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
   email     String   @unique
   password  String
   name      String
+  supabaseId String?  @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,5 +1,9 @@
 import { Request, Response } from 'express';
 import { authService } from '../services/authService';
+import {
+  supabaseAuthService,
+  SupabaseAuthError,
+} from '../services/supabaseAuthService';
 import { logger } from '../utils/logger';
 
 export class AuthController {
@@ -185,13 +189,65 @@ export class AuthController {
 
     } catch (error) {
       logger.error(`Get profile error: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      
+
       res.status(500).json({
         error: {
           code: 'INTERNAL_ERROR',
           message: 'Failed to get user profile',
           timestamp: new Date().toISOString()
         }
+      });
+    }
+  }
+
+  async getSupabaseStatus(req: Request, res: Response) {
+    const status = supabaseAuthService.getStatus();
+    res.json({
+      supabase: status,
+    });
+  }
+
+  async exchangeSupabaseToken(req: Request, res: Response) {
+    try {
+      const { accessToken } = req.body;
+
+      if (!accessToken) {
+        return res.status(400).json({
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: 'Supabase access token is required',
+            timestamp: new Date().toISOString(),
+          },
+        });
+      }
+
+      const result = await supabaseAuthService.exchangeSupabaseToken(accessToken);
+
+      res.json({
+        message: 'Supabase token exchanged successfully',
+        user: result.user,
+        tokens: result.tokens,
+        supabaseUserId: result.supabaseUserId,
+      });
+    } catch (error) {
+      if (error instanceof SupabaseAuthError) {
+        return res.status(error.statusCode).json({
+          error: {
+            code: error.code,
+            message: error.message,
+            timestamp: new Date().toISOString(),
+          },
+        });
+      }
+
+      logger.error(`Supabase token exchange failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+
+      res.status(500).json({
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'Failed to exchange Supabase token',
+          timestamp: new Date().toISOString(),
+        },
       });
     }
   }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,64 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { logger } from '../utils/logger';
+
+type GlobalSupabase = typeof globalThis & {
+  __supabaseClient?: SupabaseClient | null;
+  __supabaseAdminClient?: SupabaseClient | null;
+};
+
+const globalSupabase = globalThis as GlobalSupabase;
+
+const createSupabaseClient = (key: string): SupabaseClient => {
+  const url = process.env.SUPABASE_URL;
+  if (!url) {
+    throw new Error('SUPABASE_URL environment variable is not set');
+  }
+
+  return createClient(url, key, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+};
+
+const getOrCreateClient = (key: string | undefined, cacheKey: '__supabaseClient' | '__supabaseAdminClient') => {
+  if (!key) {
+    return null;
+  }
+
+  if (!globalSupabase[cacheKey]) {
+    try {
+      globalSupabase[cacheKey] = createSupabaseClient(key);
+    } catch (error) {
+      logger.error('Failed to initialise Supabase client', {
+        error: error instanceof Error ? error.message : error,
+      });
+      globalSupabase[cacheKey] = null;
+    }
+  }
+
+  return globalSupabase[cacheKey] ?? null;
+};
+
+export const getSupabaseClient = (): SupabaseClient | null => {
+  return getOrCreateClient(process.env.SUPABASE_ANON_KEY, '__supabaseClient');
+};
+
+export const getSupabaseAdminClient = (): SupabaseClient | null => {
+  return getOrCreateClient(process.env.SUPABASE_SERVICE_ROLE_KEY, '__supabaseAdminClient');
+};
+
+export const isSupabaseConfigured = (): boolean => {
+  return Boolean(process.env.SUPABASE_URL && process.env.SUPABASE_SERVICE_ROLE_KEY);
+};
+
+export const resetSupabaseClientsForTesting = () => {
+  if ('__supabaseClient' in globalSupabase) {
+    globalSupabase.__supabaseClient = null;
+  }
+
+  if ('__supabaseAdminClient' in globalSupabase) {
+    globalSupabase.__supabaseAdminClient = null;
+  }
+};

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -8,6 +8,8 @@ const router = Router();
 router.post('/register', authController.register.bind(authController));
 router.post('/login', authController.login.bind(authController));
 router.post('/refresh', authController.refreshToken.bind(authController));
+router.get('/supabase/status', authController.getSupabaseStatus.bind(authController));
+router.post('/supabase/exchange', authController.exchangeSupabaseToken.bind(authController));
 
 // Protected routes
 router.get('/profile', authenticate, authController.getProfile.bind(authController));

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -35,6 +35,8 @@ router.get('/', (req, res) => {
       'POST /api/auth/register - User registration',
       'POST /api/auth/login - User login',
       'POST /api/auth/refresh - Refresh access token',
+      'GET /api/auth/supabase/status - Supabase integration status',
+      'POST /api/auth/supabase/exchange - Exchange Supabase session token',
       'GET /api/auth/profile - Get user profile (protected)',
       'POST /api/fams - Create a new Fam (protected)',
       'GET /api/fams/user - Get user\'s Fams (protected)',

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -128,7 +128,7 @@ export class AuthService {
   async verifyAccessToken(token: string): Promise<AuthUser> {
     try {
       const decoded = jwt.verify(token, this.JWT_SECRET) as any;
-      
+
       // Verify user still exists
       const user = await prisma.user.findUnique({
         where: { id: decoded.userId }
@@ -146,6 +146,10 @@ export class AuthService {
     } catch (error) {
       throw new Error('Invalid access token');
     }
+  }
+
+  issueTokensForUser(user: AuthUser): AuthTokens {
+    return this.generateTokens(user);
   }
 
   private generateTokens(user: AuthUser): AuthTokens {

--- a/src/services/supabaseAuthService.ts
+++ b/src/services/supabaseAuthService.ts
@@ -1,0 +1,198 @@
+import type { User as SupabaseUser } from '@supabase/supabase-js';
+import bcrypt from 'bcryptjs';
+import { prisma } from '../lib/prisma';
+import { logger } from '../utils/logger';
+import { getSupabaseAdminClient, isSupabaseConfigured } from '../lib/supabase';
+import { authService, AuthTokens, AuthUser } from './authService';
+
+export type SupabaseAuthStatus = {
+  enabled: boolean;
+  configured: boolean;
+  projectUrl: string | null;
+};
+
+export type SupabaseAuthResult = {
+  user: AuthUser;
+  tokens: AuthTokens;
+  supabaseUserId: string;
+  email: string;
+};
+
+export class SupabaseAuthError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly statusCode: number = 400
+  ) {
+    super(message);
+    this.name = 'SupabaseAuthError';
+  }
+}
+
+class SupabaseAuthService {
+  private readonly SALT_ROUNDS = 12;
+
+  isEnabled(): boolean {
+    return process.env.SUPABASE_AUTH_ENABLED === 'true';
+  }
+
+  getStatus(): SupabaseAuthStatus {
+    const enabled = this.isEnabled();
+    const configured = enabled && isSupabaseConfigured();
+
+    return {
+      enabled,
+      configured,
+      projectUrl: enabled ? process.env.SUPABASE_URL ?? null : null,
+    };
+  }
+
+  async exchangeSupabaseToken(accessToken: string): Promise<SupabaseAuthResult> {
+    if (!this.isEnabled()) {
+      throw new SupabaseAuthError(
+        'SUPABASE_DISABLED',
+        'Supabase authentication integration is not enabled',
+        503
+      );
+    }
+
+    const supabase = getSupabaseAdminClient();
+    if (!supabase) {
+      throw new SupabaseAuthError(
+        'SUPABASE_NOT_CONFIGURED',
+        'Supabase credentials are not configured',
+        503
+      );
+    }
+
+    const { data, error } = await supabase.auth.getUser(accessToken);
+
+    if (error || !data?.user) {
+      logger.warn('Supabase token verification failed', {
+        error: error?.message ?? error,
+      });
+      throw new SupabaseAuthError(
+        'SUPABASE_TOKEN_INVALID',
+        'Supabase access token could not be verified',
+        401
+      );
+    }
+
+    const supabaseUser = data.user;
+    const email = supabaseUser.email?.toLowerCase();
+
+    if (!email) {
+      throw new SupabaseAuthError(
+        'SUPABASE_USER_MISSING_EMAIL',
+        'Supabase user does not have an email address',
+        400
+      );
+    }
+
+    const prismaUser = await this.syncSupabaseUser(supabaseUser, email);
+
+    const authUser: AuthUser = {
+      id: prismaUser.id,
+      email: prismaUser.email,
+      name: prismaUser.name,
+    };
+
+    const tokens = authService.issueTokensForUser(authUser);
+
+    return {
+      user: authUser,
+      tokens,
+      supabaseUserId: supabaseUser.id,
+      email,
+    };
+  }
+
+  private resolveDisplayName(
+    supabaseUser: SupabaseUser,
+    currentName?: string | null
+  ): string {
+    const metadata = supabaseUser.user_metadata ?? {};
+    const metadataName =
+      metadata.full_name || metadata.name || metadata.preferred_username;
+
+    if (typeof metadataName === 'string' && metadataName.trim().length > 0) {
+      return metadataName.trim();
+    }
+
+    if (currentName && currentName.trim().length > 0) {
+      return currentName;
+    }
+
+    const email = supabaseUser.email ?? '';
+    return email.split('@')[0] || 'Supabase User';
+  }
+
+  private async syncSupabaseUser(
+    supabaseUser: SupabaseUser,
+    email: string
+  ) {
+    try {
+      let user = await prisma.user.findFirst({
+        where: {
+          OR: [
+            { supabaseId: supabaseUser.id },
+            { email },
+          ],
+        },
+      });
+
+      const displayName = this.resolveDisplayName(supabaseUser, user?.name);
+
+      if (!user) {
+        const passwordSeed = `supabase:${supabaseUser.id}:${email}`;
+        const hashedPassword = await bcrypt.hash(passwordSeed, this.SALT_ROUNDS);
+
+        user = await prisma.user.create({
+          data: {
+            email,
+            name: displayName,
+            password: hashedPassword,
+            supabaseId: supabaseUser.id,
+          },
+        });
+
+        logger.info('Created local user from Supabase identity', {
+          supabaseId: supabaseUser.id,
+          email,
+        });
+      } else {
+        const updates: { supabaseId?: string; name?: string } = {};
+
+        if (!user.supabaseId) {
+          updates.supabaseId = supabaseUser.id;
+        }
+
+        if (displayName && displayName !== user.name) {
+          updates.name = displayName;
+        }
+
+        if (Object.keys(updates).length > 0) {
+          user = await prisma.user.update({
+            where: { id: user.id },
+            data: updates,
+          });
+        }
+      }
+
+      return user;
+    } catch (error) {
+      logger.error('Failed to synchronise Supabase user', {
+        error: error instanceof Error ? error.message : error,
+        supabaseUserId: supabaseUser.id,
+      });
+
+      throw new SupabaseAuthError(
+        'SUPABASE_SYNC_FAILED',
+        'Failed to synchronise Supabase user with FamSpace',
+        500
+      );
+    }
+  }
+}
+
+export const supabaseAuthService = new SupabaseAuthService();

--- a/tests/unit/services/supabaseAuthService.test.ts
+++ b/tests/unit/services/supabaseAuthService.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getHashMock = () => (globalThis as any).__supabaseHashMock as ReturnType<typeof vi.fn>;
+
+vi.mock('bcryptjs', () => {
+  const hashMock = vi.fn();
+  (globalThis as any).__supabaseHashMock = hashMock;
+  return {
+    default: {
+      hash: (...args: unknown[]) => hashMock(...(args as [])),
+    },
+    hash: (...args: unknown[]) => hashMock(...(args as [])),
+  };
+});
+
+type PrismaMock = {
+  user: {
+    findFirst: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+const getPrismaMock = () => (globalThis as any).__supabasePrismaMock as PrismaMock;
+
+vi.mock('../../../src/lib/prisma', () => {
+  const prismaMock: PrismaMock = {
+    user: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+  };
+
+  (globalThis as any).__supabasePrismaMock = prismaMock;
+
+  return {
+    prisma: prismaMock,
+  };
+});
+
+type SupabaseLibMocks = {
+  getSupabaseAdminClient: ReturnType<typeof vi.fn>;
+  isSupabaseConfigured: ReturnType<typeof vi.fn>;
+};
+
+const getSupabaseMocks = () =>
+  (globalThis as any).__supabaseLibMocks as SupabaseLibMocks;
+
+vi.mock('../../../src/lib/supabase', () => {
+  const mocks: SupabaseLibMocks = {
+    getSupabaseAdminClient: vi.fn(),
+    isSupabaseConfigured: vi.fn(),
+  };
+
+  (globalThis as any).__supabaseLibMocks = mocks;
+
+  return mocks;
+});
+
+import { authService } from '../../../src/services/authService';
+import {
+  supabaseAuthService,
+  SupabaseAuthError,
+} from '../../../src/services/supabaseAuthService';
+
+const issueTokensSpy = vi.spyOn(authService, 'issueTokensForUser');
+
+let prismaMock: PrismaMock;
+let supabaseMocks: SupabaseLibMocks;
+
+const createSupabaseUser = () => ({
+  id: 'supabase-user-id',
+  email: 'User@Example.com',
+  user_metadata: {
+    full_name: 'Example User',
+  },
+});
+
+describe('SupabaseAuthService', () => {
+  beforeEach(() => {
+    process.env.SUPABASE_AUTH_ENABLED = 'true';
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    const hashMock = getHashMock();
+    hashMock.mockReset();
+    hashMock.mockResolvedValue('hashed-password');
+    prismaMock = getPrismaMock();
+    Object.values(prismaMock.user).forEach((fn) => (fn as any).mockReset());
+    supabaseMocks = getSupabaseMocks();
+    supabaseMocks.getSupabaseAdminClient.mockReset();
+    supabaseMocks.isSupabaseConfigured.mockReset();
+    supabaseMocks.isSupabaseConfigured.mockReturnValue(true);
+    issueTokensSpy.mockClear();
+    issueTokensSpy.mockReturnValue({
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+    });
+  });
+
+  it('reports disabled status when integration is off', () => {
+    process.env.SUPABASE_AUTH_ENABLED = 'false';
+    const status = supabaseAuthService.getStatus();
+    expect(status.enabled).toBe(false);
+    expect(status.configured).toBe(false);
+    expect(status.projectUrl).toBeNull();
+  });
+
+  it('throws when integration is disabled', async () => {
+    process.env.SUPABASE_AUTH_ENABLED = 'false';
+
+    await expect(
+      supabaseAuthService.exchangeSupabaseToken('token')
+    ).rejects.toMatchObject({
+      code: 'SUPABASE_DISABLED',
+    });
+  });
+
+  it('throws when Supabase client is not configured', async () => {
+    supabaseMocks.getSupabaseAdminClient.mockReturnValue(null);
+
+    await expect(
+      supabaseAuthService.exchangeSupabaseToken('token')
+    ).rejects.toMatchObject({
+      code: 'SUPABASE_NOT_CONFIGURED',
+    });
+  });
+
+  it('creates a local user from Supabase token', async () => {
+    const supabaseUser = createSupabaseUser();
+
+    supabaseMocks.getSupabaseAdminClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: supabaseUser },
+          error: null,
+        }),
+      },
+    });
+
+    prismaMock.user.findFirst.mockResolvedValue(null);
+    prismaMock.user.create.mockResolvedValue({
+      id: 'local-user-id',
+      email: 'user@example.com',
+      name: 'Example User',
+      supabaseId: supabaseUser.id,
+    });
+
+    const result = await supabaseAuthService.exchangeSupabaseToken('token');
+
+    expect(prismaMock.user.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          email: 'user@example.com',
+          supabaseId: supabaseUser.id,
+        }),
+      })
+    );
+    expect(result.user.email).toBe('user@example.com');
+    expect(result.supabaseUserId).toBe(supabaseUser.id);
+    expect(authService.issueTokensForUser).toHaveBeenCalledWith({
+      id: 'local-user-id',
+      email: 'user@example.com',
+      name: 'Example User',
+    });
+  });
+
+  it('updates existing user metadata when Supabase data changes', async () => {
+    const supabaseUser = createSupabaseUser();
+
+    supabaseMocks.getSupabaseAdminClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: supabaseUser },
+          error: null,
+        }),
+      },
+    });
+
+    prismaMock.user.findFirst.mockResolvedValue({
+      id: 'local-user-id',
+      email: 'user@example.com',
+      name: 'Old Name',
+      supabaseId: null,
+    });
+
+    prismaMock.user.update.mockResolvedValue({
+      id: 'local-user-id',
+      email: 'user@example.com',
+      name: 'Example User',
+      supabaseId: supabaseUser.id,
+    });
+
+    const result = await supabaseAuthService.exchangeSupabaseToken('token');
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith({
+      where: { id: 'local-user-id' },
+      data: {
+        name: 'Example User',
+        supabaseId: supabaseUser.id,
+      },
+    });
+    expect(result.user.name).toBe('Example User');
+  });
+
+  it('wraps synchronisation errors', async () => {
+    const supabaseUser = createSupabaseUser();
+
+    supabaseMocks.getSupabaseAdminClient.mockReturnValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: supabaseUser },
+          error: null,
+        }),
+      },
+    });
+
+    prismaMock.user.findFirst.mockRejectedValue(new Error('db unavailable'));
+
+    await expect(
+      supabaseAuthService.exchangeSupabaseToken('token')
+    ).rejects.toBeInstanceOf(SupabaseAuthError);
+  });
+});


### PR DESCRIPTION
## Summary
- add Supabase client utilities and service layer to exchange Supabase session tokens for FamSpace JWTs
- expose new authentication endpoints, schema support, and environment variables for Supabase plus deployment guidance for Vercel
- cover the integration with targeted unit tests and add deployment-friendly npm scripts

## Testing
- npx vitest run tests/unit/services/supabaseAuthService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc21f7ecc08321ba1421ac9d951ebd